### PR TITLE
Apply PAdES plugin adjustments

### DIFF
--- a/crypto/ts/ts_rsp_verify.c
+++ b/crypto/ts/ts_rsp_verify.c
@@ -162,6 +162,12 @@ int TS_RESP_verify_signature(PKCS7 *token, STACK_OF(X509) *certs,
  * The certificate chain is returned in chain. Caller is responsible for
  * freeing the vector.
  */
+int TS_verify_cert(X509_STORE *store, STACK_OF(X509) *untrusted,
+                          X509 *signer, STACK_OF(X509) **chain)
+{
+    return ts_verify_cert(store, untrusted, signer, chain);
+}
+
 static int ts_verify_cert(X509_STORE *store, STACK_OF(X509) *untrusted,
                           X509 *signer, STACK_OF(X509) **chain)
 {

--- a/crypto/x509v3/v3_purp.c
+++ b/crypto/x509v3/v3_purp.c
@@ -732,9 +732,9 @@ static int check_purpose_timestamp_sign(const X509_PURPOSE *xp, const X509 *x,
      * and/or nonRepudiation (other values are not consistent and shall
      * be rejected).
      */
-    if ((x->ex_flags & EXFLAG_KUSAGE)
-        && ((x->ex_kusage & ~(KU_NON_REPUDIATION | KU_DIGITAL_SIGNATURE)) ||
-            !(x->ex_kusage & (KU_NON_REPUDIATION | KU_DIGITAL_SIGNATURE))))
+    if ((x->ex_flags & EXFLAG_KUSAGE) &&
+        // ((x->ex_kusage & ~(KU_NON_REPUDIATION | KU_DIGITAL_SIGNATURE)) ||
+            !(x->ex_kusage & (KU_NON_REPUDIATION | KU_DIGITAL_SIGNATURE)))
         return 0;
 
     /* Only time stamp key usage is permitted and it's required. */

--- a/include/openssl/ts.h
+++ b/include/openssl/ts.h
@@ -419,6 +419,9 @@ TS_RESP *TS_RESP_create_response(TS_RESP_CTX *ctx, BIO *req_bio);
 int TS_RESP_verify_signature(PKCS7 *token, STACK_OF(X509) *certs,
                              X509_STORE *store, X509 **signer_out);
 
+int TS_verify_cert(X509_STORE *store, STACK_OF(X509) *untrusted,
+  X509 *signer, STACK_OF(X509) **chain);
+
 /* Context structure for the generic verify method. */
 
 /* Verify the signer's certificate and the signature of the response. */


### PR DESCRIPTION
Ajustes na biblioteca para funcionamento com pades-plugin.
1. Verificação de CMS de TimeStamp dentro do `CMS_Verify()`
1. Correção de retorno de código de erro de verificação de certificado X509
1. Correção de verificação de "propósito" de certificado de carimbo do tempo